### PR TITLE
Reflect new database restriction for sandboxes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ default_config: &defaults
   disk_quota: 512M
   timeout: 180
   services:
-    - database # cf create-service aws-rds medium-mysql database
+    - database # cf create-service aws-rds shared-mysql database
     - secrets  # cf create-user-provided-service secrets -p '{
                # "CRON_KEY": ...
                # "HASH_SALT": ...


### PR DESCRIPTION
Similar to 2d834538c3e7b145fa08b2e1747489169248058b, but for databases: cloud.gov now limits sandbox accounts to 'shared' instances. For more information, run 'cf marketplace' to see which services require payment and which don't.

Changes proposed in this pull request:
- Update the provided database service creation command such that it'll work for people trying this with sandbox accounts.
