### PR TITLE
Handle "no s3 service defined in VCAP_SERVICES" properly

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,8 +5,8 @@ SECRETS=$(echo $VCAP_SERVICES | jq -r '.["user-provided"][] | select(.name == "s
 APP_NAME=$(echo $VCAP_APPLICATION | jq -r '.name')
 APP_ROOT=$(dirname "${BASH_SOURCE[0]}")
 
-S3_BUCKET=$(echo $VCAP_SERVICES | jq -r '.["s3"][] | select(.name == "storage") | .credentials.bucket')
-S3_REGION=$(echo $VCAP_SERVICES | jq -r '.["s3"][] | select(.name == "storage") | .credentials.region')
+S3_BUCKET=$(echo $VCAP_SERVICES | jq -r '.["s3"][]? | select(.name == "storage") | .credentials.bucket')
+S3_REGION=$(echo $VCAP_SERVICES | jq -r '.["s3"][]? | select(.name == "storage") | .credentials.region')
 if [ -n "$S3_BUCKET" ] && [ -n "$S3_REGION" ]; then
   # Add Proxy rewrite rules to the top of the htaccess file
   sed -i "s/S3_BUCKET/$S3_BUCKET/g" $APP_ROOT/web/.htaccess


### PR DESCRIPTION
`docker-compose.yml` doesn't include an `s3` service. Although the ensuing code works fine with `S3_BUCKET` and `S3_REGION` having value `null`, it's never reached because `jq` expects there to be an `s3` service and errors out.

This changes makes the jq filter more forgiving so that it doesn't error out and a null value is assigned. I'm not sure that's all we need in the world, but it at least gets a working site immediately after you run `docker-compose up`.