### PR TITLE
Grab/set S3 env vars upon startup

### DIFF
--- a/.profile
+++ b/.profile
@@ -2,6 +2,11 @@
 # this code is executed while initializing the app:
 # https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#profile
 
+S3_BUCKET=$(echo "$VCAP_SERVICES" | jq -r '.["s3"][]? | select(.name == "storage") | .credentials.bucket')
+export S3_BUCKET
+S3_REGION=$(echo "$VCAP_SERVICES" | jq -r '.["s3"][]? | select(.name == "storage") | .credentials.region')
+export S3_REGION
+
 if [ -f /app/web/.htaccess ] ; then
   if [ -n "$S3_BUCKET" ] && [ -n "$S3_REGION" ]; then
     # Add Proxy rewrite rules to the top of the htaccess file

--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -60,9 +60,6 @@ else
   cf create-service s3 basic-sandbox storage
 fi
 
-# create this to figure out where to set the s3 stuff
-cf create-service-key storage storagekey
-
 # wait until the db is fully provisioned
 until cf create-service-key database test-db-ok ; do
 	echo waiting until database is live...
@@ -72,16 +69,6 @@ cf delete-service-key database test-db-ok -f
 
 # launch the apps
 cf push
-
-# make sure that the app knows where it's s3fs stuff lives
-S3INFO=$(cf service-key storage storagekey)
-S3_BUCKET=$(echo "$S3INFO" | grep '"bucket":' | sed 's/.*"bucket": "\(.*\)",/\1/')
-S3_REGION=$(echo "$S3INFO" | grep '"region":' | sed 's/.*"region": "\(.*\)",/\1/')
-cf set-env web S3_BUCKET "$S3_BUCKET"
-cf set-env web S3_REGION "$S3_REGION"
-cf delete-service-key storage storagekey -f
-# This is a bit heavyweight, but it is the only way to get the environment variables to take effect.
-cf restage web
 
 # tell people where to go
 ROUTE=$(cf apps | grep web | awk '{print $6}')


### PR DESCRIPTION
`.profile` runs after the app droplet is loaded, but before the app runs. So we can just grab and apply the S3 service details from the VCAP_SERVICES env var right then. This removes the need to restage the two apps just to get S3 creds, which means that the time to deploy is cut in half.
